### PR TITLE
chore: upgrade Flask dependency to 3.1.3 series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.3.2
-requests==2.32.4 
+Flask~=3.1.3
+requests==2.32.4


### PR DESCRIPTION
### Motivation
- Address the reported vulnerability in Flask (< 3.1.3, CVE-2026-27205) by moving the project onto the secure 3.1.3-compatible release series.

### Description
- Replace `Flask==2.3.2` with `Flask~=3.1.3` in `requirements.txt` to pin to the 3.1.3-compatible series.

### Testing
- Attempted to run `python -m pip install -r requirements.txt`, but installation could not complete in this environment due to proxy/network restrictions (`Tunnel connection failed: 403 Forbidden`); the file change itself was verified to contain `Flask~=3.1.3`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ad649038833294d65efefd73ac32)