### PR TITLE
Bump requests to ~=2.33.0 to remediate CVE-2026-25645

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Flask~=3.1.3
-requests==2.32.4 
+requests~=2.33.0


### PR DESCRIPTION
### Motivation
- Upgrade `requests` out of the vulnerable `< 2.33.0` range to remediate CVE-2026-25645.

### Description
- Update `requirements.txt` to replace `requests==2.32.4` with `requests~=2.33.0`.

### Testing
- Ran `python -m pip install --dry-run -r requirements.txt` but package resolution failed due to an environment proxy/network `ProxyError` (403), so installation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d451352a608332a3071f4c712cd840)